### PR TITLE
Py2to3 tests refactor

### DIFF
--- a/tests/scripts/convert_test_events.py
+++ b/tests/scripts/convert_test_events.py
@@ -12,7 +12,7 @@ def convert_test_event(path):
         try:
             data = json.load(test_event)
         except ValueError as err:
-            print '[ERROR] {}: {}'.format(os.path.basename(path), err)
+            print('[ERROR] {}: {}'.format(os.path.basename(path), err))
             return
         # Convert legacy test events
         if isinstance(data, dict) and 'records' in data:

--- a/tests/scripts/sort_configs.py
+++ b/tests/scripts/sort_configs.py
@@ -30,7 +30,7 @@ class JsonFileSorter(object):
         schema = json.loads(original_text, object_pairs_hook=OrderedDict)
 
         # Sort the loaded schema by top-level key. Preserve the ordering of internal keys.
-        ordered_schema = OrderedDict(sorted(schema.items(), key=lambda k: k[0]))
+        ordered_schema = OrderedDict(sorted(list(schema.items()), key=lambda k: k[0]))
 
         with open(file_path, 'w') as outfile:
             json.dump(ordered_schema, outfile, indent=2, separators=(',', ': '))

--- a/tests/unit/helpers/aws_mocks.py
+++ b/tests/unit/helpers/aws_mocks.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 from datetime import datetime
 import uuid
-from StringIO import StringIO
+from io import StringIO
 import zipfile
 
 import boto3

--- a/tests/unit/helpers/config.py
+++ b/tests/unit/helpers/config.py
@@ -32,7 +32,7 @@ class MockCLIConfig(object):
         self.config.__setitem__(key, new_value)
 
     def clusters(self):
-        return self.config['clusters'].keys()
+        return list(self.config['clusters'].keys())
 
     def get(self, key):
         return self.config.get(key)

--- a/tests/unit/publishers/community/test_generic.py
+++ b/tests/unit/publishers/community/test_generic.py
@@ -321,7 +321,7 @@ class TestEnumerateFields(object):
             'staged',
         ]
 
-        assert_equal(publication.keys(), expectation)
+        assert_equal(list(publication.keys()), expectation)
 
 
 def test_delete_dictionary_fields():

--- a/tests/unit/stream_alert_alert_processor/test_outputs/credentials/test_provider.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/credentials/test_provider.py
@@ -355,8 +355,8 @@ class TestS3Driver(object):
         loaded_creds = json.loads(credentials.get_data_kms_decrypted())
 
         assert_equal(len(loaded_creds), 2)
-        assert_equal(loaded_creds['url'], u'http://www.foo.bar/test')
-        assert_equal(loaded_creds['token'], u'token_to_encrypt')
+        assert_equal(loaded_creds['url'], 'http://www.foo.bar/test')
+        assert_equal(loaded_creds['token'], 'token_to_encrypt')
 
     def test_has_credentials(self):
         """S3Driver - Has Credentials

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
@@ -21,7 +21,7 @@ from nose.tools import (
     assert_is_instance,
     assert_is_not_none,
     assert_is_none,
-    assert_items_equal
+    assert_count_equal
 )
 from requests.exceptions import Timeout as ReqTimeout
 
@@ -108,7 +108,7 @@ def test_output_loading():
         'phantom',
         'slack'
     }
-    assert_items_equal(loaded_outputs, expected_outputs)
+    assert_count_equal(loaded_outputs, expected_outputs)
 
 
 @patch.object(OutputDispatcher, '__service__', 'test_service')

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_output_base.py
@@ -80,7 +80,7 @@ def test_create_dispatcher():
 
 def test_user_defined_properties():
     """OutputDispatcher - User Defined Properties"""
-    for output in StreamAlertOutput.get_all_outputs().values():
+    for output in list(StreamAlertOutput.get_all_outputs().values()):
         props = output.get_user_defined_properties()
         # The user defined properties should at a minimum contain a descriptor
         assert_is_not_none(props.get('descriptor'))
@@ -185,8 +185,8 @@ class TestOutputDispatcher(object):
 
         assert_is_not_none(loaded_creds)
         assert_equal(len(loaded_creds), 2)
-        assert_equal(loaded_creds['url'], u'http://www.foo.bar/test')
-        assert_equal(loaded_creds['token'], u'token_to_encrypt')
+        assert_equal(loaded_creds['url'], 'http://www.foo.bar/test')
+        assert_equal(loaded_creds['token'], 'token_to_encrypt')
 
     def test_format_output_config(self):
         """OutputDispatcher - Format Output Config"""

--- a/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
+++ b/tests/unit/stream_alert_alert_processor/test_outputs/test_pagerduty.py
@@ -1614,7 +1614,7 @@ class RequestMocker(object):
     def inspect_calls(mock):
         """Prints out all of the calls to this mock, in the order of call.
         """
-        print mock.call_args_list
+        print(mock.call_args_list)
 
     @staticmethod
     def assert_mock_with_no_calls_like(mock, condition):

--- a/tests/unit/stream_alert_alert_processor/test_publishers/slack/test_slack_layout.py
+++ b/tests/unit/stream_alert_alert_processor/test_publishers/slack/test_slack_layout.py
@@ -73,8 +73,8 @@ class TestSummary(object):
         )
         assert_equal(len(publication['@slack.attachments']), len(expectation['@slack.attachments']))
         assert_equal(
-            publication['@slack.attachments'][0].keys(),
-            expectation['@slack.attachments'][0].keys()
+            list(publication['@slack.attachments'][0].keys()),
+            list(expectation['@slack.attachments'][0].keys())
         )
         assert_equal(publication['@slack.attachments'][0], expectation['@slack.attachments'][0])
 

--- a/tests/unit/stream_alert_apps/test_apps/test_aliyun.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_aliyun.py
@@ -17,7 +17,7 @@ import os
 
 from mock import patch
 from moto import mock_ssm
-from nose.tools import assert_equal, assert_false, assert_items_equal
+from nose.tools import assert_equal, assert_false, assert_count_equal
 
 from aliyunsdkcore.acs_exception.exceptions import ServerException
 
@@ -52,7 +52,7 @@ class TestAliyunApp(object):
 
     def test_required_auth_info(self):
         """AliyunApp - Required Auth Info"""
-        assert_items_equal(list(self._app.required_auth_info().keys()),
+        assert_count_equal(list(self._app.required_auth_info().keys()),
                            {'access_key_id', 'access_key_secret', 'region_id'})
 
     def test_region_validator_success(self):

--- a/tests/unit/stream_alert_apps/test_apps/test_aliyun.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_aliyun.py
@@ -52,7 +52,7 @@ class TestAliyunApp(object):
 
     def test_required_auth_info(self):
         """AliyunApp - Required Auth Info"""
-        assert_items_equal(self._app.required_auth_info().keys(),
+        assert_items_equal(list(self._app.required_auth_info().keys()),
                            {'access_key_id', 'access_key_secret', 'region_id'})
 
     def test_region_validator_success(self):

--- a/tests/unit/stream_alert_apps/test_apps/test_app_base.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_app_base.py
@@ -22,7 +22,7 @@ from nose.tools import (
     assert_equal,
     assert_false,
     assert_is_instance,
-    assert_items_equal,
+    assert_count_equal,
     assert_true,
     raises
 )
@@ -67,7 +67,7 @@ class TestStreamAlertApp(object):
             'aliyun_actiontrail'
         }
 
-        assert_items_equal(expected_apps, StreamAlertApp.get_all_apps())
+        assert_count_equal(expected_apps, StreamAlertApp.get_all_apps())
 
     @patch('stream_alert.apps.app_base.Batcher', Mock())
     def test_get_app(self):

--- a/tests/unit/stream_alert_apps/test_apps/test_box.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_box.py
@@ -19,7 +19,7 @@ import os
 from boxsdk.exception import BoxException
 from mock import Mock, mock_open, patch
 from moto import mock_ssm
-from nose.tools import assert_equal, assert_false, assert_items_equal, assert_true
+from nose.tools import assert_equal, assert_false, assert_count_equal, assert_true
 from requests.exceptions import ConnectionError, Timeout
 
 from stream_alert.apps._apps.box import BoxApp
@@ -50,7 +50,7 @@ class TestBoxApp(object):
 
     def test_required_auth_info(self):
         """BoxApp - Required Auth Info"""
-        assert_items_equal(list(self._app.required_auth_info().keys()), {'keyfile'})
+        assert_count_equal(list(self._app.required_auth_info().keys()), {'keyfile'})
 
     @patch('stream_alert.apps._apps.box.JWTAuth.from_settings_dictionary',
            Mock(return_value=True))

--- a/tests/unit/stream_alert_apps/test_apps/test_box.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_box.py
@@ -50,7 +50,7 @@ class TestBoxApp(object):
 
     def test_required_auth_info(self):
         """BoxApp - Required Auth Info"""
-        assert_items_equal(self._app.required_auth_info().keys(), {'keyfile'})
+        assert_items_equal(list(self._app.required_auth_info().keys()), {'keyfile'})
 
     @patch('stream_alert.apps._apps.box.JWTAuth.from_settings_dictionary',
            Mock(return_value=True))

--- a/tests/unit/stream_alert_apps/test_apps/test_duo.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_duo.py
@@ -53,7 +53,7 @@ class TestDuoApp(object):
     def test_generate_auth(self):
         """DuoApp - Generate Auth"""
         auth = self._app._generate_auth('hostname', {})
-        assert_items_equal(auth.keys(), {'Date', 'Authorization', 'Host'})
+        assert_items_equal(list(auth.keys()), {'Date', 'Authorization', 'Host'})
 
     def test_sleep(self):
         """DuoApp - Sleep Seconds"""
@@ -64,7 +64,7 @@ class TestDuoApp(object):
 
     def test_required_auth_info(self):
         """DuoApp - Required Auth Info"""
-        assert_items_equal(self._app.required_auth_info().keys(),
+        assert_items_equal(list(self._app.required_auth_info().keys()),
                            {'api_hostname', 'integration_key', 'secret_key'})
 
     @staticmethod

--- a/tests/unit/stream_alert_apps/test_apps/test_duo.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_duo.py
@@ -17,7 +17,7 @@ import os
 
 from mock import Mock, patch
 from moto import mock_ssm
-from nose.tools import assert_equal, assert_false, assert_items_equal, raises
+from nose.tools import assert_equal, assert_false, assert_count_equal, raises
 import requests
 
 from stream_alert.apps._apps.duo import DuoAdminApp, DuoApp, DuoAuthApp
@@ -53,7 +53,7 @@ class TestDuoApp(object):
     def test_generate_auth(self):
         """DuoApp - Generate Auth"""
         auth = self._app._generate_auth('hostname', {})
-        assert_items_equal(list(auth.keys()), {'Date', 'Authorization', 'Host'})
+        assert_count_equal(list(auth.keys()), {'Date', 'Authorization', 'Host'})
 
     def test_sleep(self):
         """DuoApp - Sleep Seconds"""
@@ -64,7 +64,7 @@ class TestDuoApp(object):
 
     def test_required_auth_info(self):
         """DuoApp - Required Auth Info"""
-        assert_items_equal(list(self._app.required_auth_info().keys()),
+        assert_count_equal(list(self._app.required_auth_info().keys()),
                            {'api_hostname', 'integration_key', 'secret_key'})
 
     @staticmethod

--- a/tests/unit/stream_alert_apps/test_apps/test_gsuite.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_gsuite.py
@@ -23,7 +23,7 @@ import apiclient
 import oauth2client
 from mock import Mock, mock_open, patch
 from moto import mock_ssm
-from nose.tools import assert_equal, assert_false, assert_items_equal, assert_true, raises
+from nose.tools import assert_equal, assert_false, assert_count_equal, assert_true, raises
 
 from stream_alert.apps._apps.gsuite import GSuiteReportsApp
 
@@ -54,7 +54,7 @@ class TestGSuiteReportsApp(object):
 
     def test_required_auth_info(self):
         """GSuiteReportsApp - Required Auth Info"""
-        assert_items_equal(list(self._app.required_auth_info().keys()),
+        assert_count_equal(list(self._app.required_auth_info().keys()),
                            {'delegation_email', 'keyfile'})
 
     @patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_dict',

--- a/tests/unit/stream_alert_apps/test_apps/test_gsuite.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_gsuite.py
@@ -54,7 +54,7 @@ class TestGSuiteReportsApp(object):
 
     def test_required_auth_info(self):
         """GSuiteReportsApp - Required Auth Info"""
-        assert_items_equal(self._app.required_auth_info().keys(),
+        assert_items_equal(list(self._app.required_auth_info().keys()),
                            {'delegation_email', 'keyfile'})
 
     @patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_dict',
@@ -275,7 +275,7 @@ class TestGSuiteReportsApp(object):
             'kind': 'audit#activity',
             'id': {
                 'time': _get_timestamp('2011-06-17T15:39:18.460000Z', index),
-                'uniqueQualifier': -12345678901234567890L + index,
+                'uniqueQualifier': -12345678901234567890 + index,
                 'applicationName': 'admin',
                 'customerId': 'C03az79cb'
             },

--- a/tests/unit/stream_alert_apps/test_apps/test_onelogin.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_onelogin.py
@@ -85,7 +85,7 @@ class TestOneLoginApp(object):
 
     def test_required_auth_info(self):
         """OneLoginApp - Required Auth Info"""
-        assert_items_equal(self._app.required_auth_info().keys(),
+        assert_items_equal(list(self._app.required_auth_info().keys()),
                            {'region', 'client_secret', 'client_id'})
 
     @staticmethod

--- a/tests/unit/stream_alert_apps/test_apps/test_onelogin.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_onelogin.py
@@ -17,7 +17,7 @@ import os
 
 from mock import Mock, patch
 from moto import mock_ssm
-from nose.tools import assert_equal, assert_false, assert_items_equal
+from nose.tools import assert_equal, assert_false, assert_count_equal
 
 from stream_alert.apps._apps.onelogin import OneLoginApp
 
@@ -85,7 +85,7 @@ class TestOneLoginApp(object):
 
     def test_required_auth_info(self):
         """OneLoginApp - Required Auth Info"""
-        assert_items_equal(list(self._app.required_auth_info().keys()),
+        assert_count_equal(list(self._app.required_auth_info().keys()),
                            {'region', 'client_secret', 'client_id'})
 
     @staticmethod

--- a/tests/unit/stream_alert_apps/test_apps/test_salesforce.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_salesforce.py
@@ -21,7 +21,7 @@ from nose.tools import (
     assert_equal,
     assert_false,
     assert_true,
-    assert_items_equal,
+    assert_count_equal,
     raises
 )
 from requests.exceptions import Timeout
@@ -112,7 +112,7 @@ class TestSalesforceApp(object):
 
     def test_required_auth_info(self):
         """SalesforceApp - Required Auth Info"""
-        assert_items_equal(
+        assert_count_equal(
             list(self._app.required_auth_info().keys()),
             {'client_id', 'client_secret', 'username', 'password', 'security_token'}
         )

--- a/tests/unit/stream_alert_apps/test_apps/test_salesforce.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_salesforce.py
@@ -113,7 +113,7 @@ class TestSalesforceApp(object):
     def test_required_auth_info(self):
         """SalesforceApp - Required Auth Info"""
         assert_items_equal(
-            self._app.required_auth_info().keys(),
+            list(self._app.required_auth_info().keys()),
             {'client_id', 'client_secret', 'username', 'password', 'security_token'}
         )
 

--- a/tests/unit/stream_alert_apps/test_apps/test_slack.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_slack.py
@@ -17,7 +17,7 @@ import os
 
 from mock import Mock, patch
 from moto import mock_ssm
-from nose.tools import assert_equal, assert_false, assert_items_equal, raises
+from nose.tools import assert_equal, assert_false, assert_count_equal, raises
 
 from stream_alert.apps._apps.slack import SlackApp, SlackAccessApp, SlackIntegrationsApp
 from tests.unit.stream_alert_apps.test_helpers import get_event, put_mock_params
@@ -43,7 +43,7 @@ class TestSlackApp(object):
 
     def test_required_auth_info(self):
         """SlackApp - Required Auth Info"""
-        assert_items_equal(list(self._app.required_auth_info().keys()), {'auth_token'})
+        assert_count_equal(list(self._app.required_auth_info().keys()), {'auth_token'})
 
     @patch('requests.post')
     @patch('logging.Logger.error')

--- a/tests/unit/stream_alert_apps/test_apps/test_slack.py
+++ b/tests/unit/stream_alert_apps/test_apps/test_slack.py
@@ -43,7 +43,7 @@ class TestSlackApp(object):
 
     def test_required_auth_info(self):
         """SlackApp - Required Auth Info"""
-        assert_items_equal(self._app.required_auth_info().keys(), {'auth_token'})
+        assert_items_equal(list(self._app.required_auth_info().keys()), {'auth_token'})
 
     @patch('requests.post')
     @patch('logging.Logger.error')
@@ -228,14 +228,14 @@ class TestSlackAccessApp(object):
 
         self._app._last_timestamp = 1522922593
         gathered_logs = self._app._gather_logs()
-        assert 'before' not in requests_mock.call_args[1]['data'].keys()
+        assert 'before' not in list(requests_mock.call_args[1]['data'].keys())
         assert_equal(len(gathered_logs), 0)
         assert_equal(self._app._next_page, 1)
         assert_equal(True, self._app._more_to_poll)
         assert_equal(self._app._before_time, logs['logins'][-1]['date_first'])
 
         self._app._gather_logs()
-        assert 'before' in requests_mock.call_args[1]['data'].keys()
+        assert 'before' in list(requests_mock.call_args[1]['data'].keys())
 
 
 @mock_ssm

--- a/tests/unit/stream_alert_apps/test_helpers.py
+++ b/tests/unit/stream_alert_apps/test_helpers.py
@@ -30,7 +30,7 @@ def put_mock_params(app_type):
         '{}_auth'.format(app_type): _get_auth_info(app_type)
     }
     ssm_client = boto3.client('ssm')
-    for key, value in params.iteritems():
+    for key, value in params.items():
         ssm_client.put_parameter(
             Name=key,
             Value=json.dumps(value),

--- a/tests/unit/stream_alert_rule_promotion/test_promoter.py
+++ b/tests/unit/stream_alert_rule_promotion/test_promoter.py
@@ -139,7 +139,7 @@ class TestRulePromoter(object):
         with patch.object(self.promoter, '_update_alert_count', Mock()), \
              patch.object(self.promoter, '_promote_rules', Mock()):
             self.promoter.run(True)
-            publish_mock.assert_called_with(self.promoter._staging_stats.values())
+            publish_mock.assert_called_with(list(self.promoter._staging_stats.values()))
 
     @patch('logging.Logger.debug')
     def test_run_none_staged(self, log_mock):

--- a/tests/unit/stream_alert_rule_promotion/test_publisher.py
+++ b/tests/unit/stream_alert_rule_promotion/test_publisher.py
@@ -76,7 +76,7 @@ class TestStatsPublisher(object):
 
     def test_format_digest(self):
         """StatsPublisher - Format Digest"""
-        expected_digest = u'''\u25E6 test_rule_1
+        expected_digest = '''\u25E6 test_rule_1
 	- Staged At:					2000-01-01 01:01:01 UTC
 	- Staged Until:					2000-01-03 01:01:01 UTC
 	- Remaining Stage Time:		1d 0h 0m
@@ -125,7 +125,7 @@ class TestStatsPublisher(object):
         self.publisher._publish_message(list(self._get_fake_stats(count=1)))
 
         args = {
-            'Message': u'''\u25E6 test_rule_0
+            'Message': '''\u25E6 test_rule_0
 	- Staged At:					2000-01-01 01:01:01 UTC
 	- Staged Until:					2000-01-03 01:01:01 UTC
 	- Remaining Stage Time:		1d 0h 0m

--- a/tests/unit/stream_alert_rule_promotion/test_statistic.py
+++ b/tests/unit/stream_alert_rule_promotion/test_statistic.py
@@ -65,7 +65,7 @@ class TestStagingStatistic(object):
         """StagingStatistic - Stringer, Past Staging"""
         self.statistic.alert_count = 200
         self.statistic._current_time += timedelta(days=2, hours=10)
-        expected_string = u'''\u25E6 test_rule
+        expected_string = '''\u25E6 test_rule
 	- Staged At:					2000-01-01 01:01:01 UTC
 	- Staged Until:					2000-01-03 01:01:01 UTC
 	- Time Past Staging:			1d 10h 0m
@@ -78,7 +78,7 @@ class TestStagingStatistic(object):
         """StagingStatistic - Stringer, Staging Remaining"""
         self.statistic.alert_count = 100
         self.statistic.execution_id = '678cc350-d4e1-4296-86d5-9351b7f92ed4'
-        expected_string = u'''\u25E6 test_rule
+        expected_string = '''\u25E6 test_rule
 	- Staged At:					2000-01-01 01:01:01 UTC
 	- Staged Until:					2000-01-03 01:01:01 UTC
 	- Remaining Stage Time:		1d 0h 0m

--- a/tests/unit/stream_alert_shared/test_alert.py
+++ b/tests/unit/stream_alert_shared/test_alert.py
@@ -121,8 +121,8 @@ class TestAlert(object):
             source_service=''
         )
         record = alert.dynamo_record()
-        assert_not_in('', record.values())
-        assert_not_in(set(), record.values())
+        assert_not_in('', list(record.values()))
+        assert_not_in(set(), list(record.values()))
 
     def test_create_from_dynamo_record(self):
         """Alert Class - Create Alert from Dynamo Record"""
@@ -143,7 +143,7 @@ class TestAlert(object):
         # Ensure result is JSON-serializable (no sets)
         assert_is_instance(json.dumps(result), str)
         # Ensure result is Athena compatible (no None values)
-        assert_not_in(None, result.values())
+        assert_not_in(None, list(result.values()))
 
     def test_can_merge_no_config(self):
         """Alert Class - Can Merge - False if Either Alert Does Not Have Merge Config"""

--- a/tests/unit/stream_alert_shared/test_athena.py
+++ b/tests/unit/stream_alert_shared/test_athena.py
@@ -21,7 +21,7 @@ from mock import Mock, patch
 from nose.tools import (
     assert_equal,
     assert_false,
-    assert_items_equal,
+    assert_count_equal,
     assert_raises,
     assert_true,
     raises
@@ -81,7 +81,7 @@ class TestAthenaClient(object):
         expected_result = {'foobar', 'barfoo', 'foobarbaz'}
 
         result = self.client._unique_values_from_query(query)
-        assert_items_equal(result, expected_result)
+        assert_count_equal(result, expected_result)
 
     def test_check_database_exists(self):
         """Athena - Check Database Exists"""
@@ -119,7 +119,7 @@ class TestAthenaClient(object):
         expected_result = {'dt=2018-12-10-10', 'dt=2018-12-09-10', 'dt=2018-12-11-10'}
 
         result = self.client.get_table_partitions('test_table')
-        assert_items_equal(result, expected_result)
+        assert_count_equal(result, expected_result)
 
     def test_get_table_partitions_error(self):
         """Athena - Get Table Partitions, Exception"""
@@ -189,7 +189,7 @@ class TestAthenaClient(object):
         ]
 
         items = list(self.client.query_result_paginator('test query'))
-        assert_items_equal(items, [{'ResultSet': {'Rows': [data]}}] * 4)
+        assert_count_equal(items, [{'ResultSet': {'Rows': [data]}}] * 4)
 
     @raises(AthenaQueryExecutionError)
     def test_query_result_paginator_error(self):

--- a/tests/unit/stream_alert_shared/test_config.py
+++ b/tests/unit/stream_alert_shared/test_config.py
@@ -16,7 +16,7 @@ limitations under the License.
 import json
 
 from mock import Mock
-from nose.tools import assert_equal, assert_items_equal, assert_raises
+from nose.tools import assert_equal, assert_count_equal, assert_raises
 from pyfakefs import fake_filesystem_unittest
 
 from stream_alert.shared.config import (
@@ -129,8 +129,8 @@ class TestConfigLoading(fake_filesystem_unittest.TestCase):
         config = load_config(include={'clusters', 'logs.json'})
         expected_keys = ['clusters', 'logs']
         expected_clusters_keys = ['prod', 'dev']
-        assert_items_equal(list(config.keys()), expected_keys)
-        assert_items_equal(list(config['clusters'].keys()), expected_clusters_keys)
+        assert_count_equal(list(config.keys()), expected_keys)
+        assert_count_equal(list(config['clusters'].keys()), expected_clusters_keys)
 
 
 class TestConfigValidation(object):

--- a/tests/unit/stream_alert_shared/test_config.py
+++ b/tests/unit/stream_alert_shared/test_config.py
@@ -129,8 +129,8 @@ class TestConfigLoading(fake_filesystem_unittest.TestCase):
         config = load_config(include={'clusters', 'logs.json'})
         expected_keys = ['clusters', 'logs']
         expected_clusters_keys = ['prod', 'dev']
-        assert_items_equal(config.keys(), expected_keys)
-        assert_items_equal(config['clusters'].keys(), expected_clusters_keys)
+        assert_items_equal(list(config.keys()), expected_keys)
+        assert_items_equal(list(config['clusters'].keys()), expected_clusters_keys)
 
 
 class TestConfigValidation(object):

--- a/tests/unit/stream_alert_shared/test_lookup_tables.py
+++ b/tests/unit/stream_alert_shared/test_lookup_tables.py
@@ -42,7 +42,7 @@ class TestLookupTables(object):
         self._put_mock_tables()
 
     def _put_mock_tables(self):
-        for bucket, files in self.buckets_info.iteritems():
+        for bucket, files in self.buckets_info.items():
             for json_file in files:
                 put_mock_s3_object(
                     bucket,

--- a/tests/unit/stream_alert_shared/test_resources.py
+++ b/tests/unit/stream_alert_shared/test_resources.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from nose.tools import assert_equal, assert_items_equal
+from nose.tools import assert_equal, assert_count_equal
 
 from stream_alert.shared import resources
 
@@ -48,7 +48,7 @@ def test_merge_required_outputs_dne():
         'alerts': 'test_streamalert_alert_delivery'
     }
 
-    assert_items_equal(outputs['aws-firehose'], expected_fh)
+    assert_count_equal(outputs['aws-firehose'], expected_fh)
 
 
 def test_merge_required_outputs_exists():
@@ -76,4 +76,4 @@ def test_merge_required_outputs_exists():
         'alerts': 'test_streamalert_alert_delivery'
     }
 
-    assert_items_equal(outputs['aws-firehose'], expected_fh)
+    assert_count_equal(outputs['aws-firehose'], expected_fh)

--- a/tests/unit/stream_alert_shared/test_rule.py
+++ b/tests/unit/stream_alert_shared/test_rule.py
@@ -61,12 +61,12 @@ def {}(_):
     return False
 """.format(rule_name)
 
-        exec custom_rule_code  # pylint: disable=exec-used
+        exec(custom_rule_code)  # pylint: disable=exec-used
 
     def test_rule_valid(self):
         """Rule - Create Valid Rule"""
         self._create_rule_helper('test_rule')
-        assert_equal(rule.Rule._rules.keys(), ['test_rule'])
+        assert_equal(list(rule.Rule._rules.keys()), ['test_rule'])
 
     @raises(rule.RuleCreationError)
     def test_rule_invalid(self):

--- a/tests/unit/stream_alert_shared/test_rule_table.py
+++ b/tests/unit/stream_alert_shared/test_rule_table.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 from datetime import datetime
 import os
-from StringIO import StringIO
+from io import StringIO
 
 from botocore.exceptions import ClientError
 from mock import Mock, patch
@@ -324,7 +324,7 @@ class TestRuleTable(object):
             'StagedUntil':  '2018-04-23T02:23:13.0Z'
         })
         with patch('sys.stdout', new=StringIO()) as stdout:
-            print self.rule_table
+            print(self.rule_table)
             expected_output = """
 Rule            Staged?
   1: test_01    False
@@ -337,7 +337,7 @@ Rule            Staged?
     def test_print_table_empty(self):
         """Rule Table - Print Table, Empty"""
         with patch('sys.stdout', new=StringIO()) as stdout:
-            print self.rule_table
+            print(self.rule_table)
             expected_output = 'Rule table is empty'
             output = stdout.getvalue().strip()
             assert_equal(output, expected_output.strip())
@@ -352,7 +352,7 @@ Rule            Staged?
             'StagedUntil':  '2018-04-23T02:23:13.0Z'
         })
         with patch('sys.stdout', new=StringIO()) as stdout:
-            print self.rule_table.__str__(True)
+            print(self.rule_table.__str__(True))
             expected_output = """
 Rule            Staged?
   1: test_01    False

--- a/tests/unit/streamalert/classifier/test_parsers_base.py
+++ b/tests/unit/streamalert/classifier/test_parsers_base.py
@@ -356,10 +356,10 @@ class TestParserBaseClassMethods(object):
             'key': 'string'
         }
         record = {
-            'key': u'\ue82a'
+            'key': '\ue82a'
         }
         assert_equal(ParserBase._convert_type(record, schema), True)
-        assert_equal(record, {'key': u'\ue82a'})
+        assert_equal(record, {'key': '\ue82a'})
 
     def test_convert_type_int(self):
         """ParserBase - Convert Type, Int"""


### PR DESCRIPTION
This pull merges the 2to3 conversion of the testing suite, along with a patched nose test assertion. Tests are still failing because of the core still not being converted.